### PR TITLE
[feat] 프로필 생성, 조회 API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ out/
 
 ### VS Code ###
 .vscode/
+
+### application.yml ###
+application.yml

--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,9 @@ dependencies {
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.6'
 	implementation 'org.projectlombok:lombok'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+	implementation 'org.springframework.boot:spring-boot-starter-security'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -21,6 +21,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.6'
 	implementation 'org.projectlombok:lombok'
+	annotationProcessor 'org.projectlombok:lombok'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/build.gradle
+++ b/build.gradle
@@ -25,6 +25,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
+	runtimeOnly 'com.mysql:mysql-connector-j'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 

--- a/src/main/java/farmsystem/backend/domain/member/dto/response/MemberResponse.java
+++ b/src/main/java/farmsystem/backend/domain/member/dto/response/MemberResponse.java
@@ -1,4 +1,4 @@
-package farmsystem.backend.domain.member.dto.resposne;
+package farmsystem.backend.domain.member.dto.response;
 
 import farmsystem.backend.domain.member.entity.Member;
 import lombok.Builder;

--- a/src/main/java/farmsystem/backend/domain/member/dto/resposne/MemberResponse.java
+++ b/src/main/java/farmsystem/backend/domain/member/dto/resposne/MemberResponse.java
@@ -1,0 +1,19 @@
+package farmsystem.backend.domain.member.dto.resposne;
+
+import farmsystem.backend.domain.member.entity.Member;
+import lombok.Builder;
+
+@Builder
+public record MemberResponse(
+        long id,
+        String username,
+        String email
+) {
+    public static MemberResponse from(Member member) {
+        return MemberResponse.builder()
+                .id(member.getId())
+                .username(member.getUsername())
+                .email(member.getEmail())
+                .build();
+    }
+}

--- a/src/main/java/farmsystem/backend/domain/member/repository/MemberRepository.java
+++ b/src/main/java/farmsystem/backend/domain/member/repository/MemberRepository.java
@@ -1,0 +1,9 @@
+package farmsystem.backend.domain.member.repository;
+
+import farmsystem.backend.domain.member.entity.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface MemberRepository extends JpaRepository<Member, Long> {
+}

--- a/src/main/java/farmsystem/backend/domain/profile/controller/ProfileApi.java
+++ b/src/main/java/farmsystem/backend/domain/profile/controller/ProfileApi.java
@@ -1,0 +1,45 @@
+package farmsystem.backend.domain.profile.controller;
+
+import farmsystem.backend.domain.profile.dto.request.CreateProfileRequest;
+import farmsystem.backend.domain.profile.dto.response.ProfileResponse;
+import farmsystem.backend.global.common.SuccessResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@Tag(name = "Profile", description = "프로필 API")
+public interface ProfileApi {
+
+    @Operation(
+            summary = "시점 프로필 생성",
+            description = "시점 프로필을 생성합니다.  \n" +
+                    "기본 프로필(실시간거래)은 회원가입 시 생성됩니다."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "201", description = "프로필 생성 성공",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = ProfileResponse.class))),
+            @ApiResponse(responseCode = "404", description = "회원을 찾을 수 없음"),
+    })
+    ResponseEntity<SuccessResponse<?>> createProfile(@AuthenticationPrincipal Long memberId,
+                                                     @RequestBody CreateProfileRequest request);
+
+    @Operation(
+            summary = "프로필 목록 조회",
+            description = "회원이 생성한 프로필 목록을 조회합니다.  \n" +
+                    "프로필 목록은 기본 프로필(실시간거래)과 시점 프로필로 나뉘어져 있습니다."
+    )
+    @ApiResponse(responseCode = "200", description = "프로필 목록 조회 성공",
+            content = @Content(mediaType = "application/json",
+                    array = @ArraySchema(
+                            schema = @Schema(implementation = ProfileResponse.class)))
+    )
+    ResponseEntity<SuccessResponse<?>> getProfileList(@AuthenticationPrincipal Long memberId);
+}

--- a/src/main/java/farmsystem/backend/domain/profile/controller/ProfileController.java
+++ b/src/main/java/farmsystem/backend/domain/profile/controller/ProfileController.java
@@ -11,7 +11,7 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/profiles")
-public class ProfileController {
+public class ProfileController implements ProfileApi {
 
     private final ProfileService profileService;
 

--- a/src/main/java/farmsystem/backend/domain/profile/controller/ProfileController.java
+++ b/src/main/java/farmsystem/backend/domain/profile/controller/ProfileController.java
@@ -1,0 +1,28 @@
+package farmsystem.backend.domain.profile.controller;
+
+import farmsystem.backend.domain.profile.dto.request.CreateProfileRequest;
+import farmsystem.backend.domain.profile.service.ProfileService;
+import farmsystem.backend.global.common.SuccessResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/profiles")
+public class ProfileController {
+
+    private final ProfileService profileService;
+
+    @PostMapping
+    public ResponseEntity<SuccessResponse<?>> createProfile(@AuthenticationPrincipal Long memberId,
+                                                            @RequestBody CreateProfileRequest request) {
+        return SuccessResponse.created(profileService.createProfile(memberId, request));
+    }
+
+    @GetMapping
+    public ResponseEntity<SuccessResponse<?>> getProfileList(@AuthenticationPrincipal Long memberId) {
+        return SuccessResponse.ok(profileService.getProfileList(memberId));
+    }
+}

--- a/src/main/java/farmsystem/backend/domain/profile/dto/request/CreateProfileRequest.java
+++ b/src/main/java/farmsystem/backend/domain/profile/dto/request/CreateProfileRequest.java
@@ -1,0 +1,23 @@
+package farmsystem.backend.domain.profile.dto.request;
+
+import farmsystem.backend.domain.member.entity.Member;
+import farmsystem.backend.domain.profile.entity.Profile;
+import farmsystem.backend.domain.profile.entity.ProfileType;
+
+import java.time.LocalDate;
+
+public record CreateProfileRequest(
+        String name,
+        long balance,
+        LocalDate startDate
+) {
+    public Profile toEntity(Member member) {
+        return Profile.builder()
+                .member(member)
+                .name(name)
+                .type(ProfileType.VIRTUAL)
+                .balance(balance)
+                .startDate(startDate)
+                .build();
+    }
+}

--- a/src/main/java/farmsystem/backend/domain/profile/dto/response/ProfileResponse.java
+++ b/src/main/java/farmsystem/backend/domain/profile/dto/response/ProfileResponse.java
@@ -1,0 +1,34 @@
+package farmsystem.backend.domain.profile.dto.response;
+
+import farmsystem.backend.domain.member.dto.resposne.MemberResponse;
+import farmsystem.backend.domain.profile.entity.Profile;
+import farmsystem.backend.domain.profile.entity.ProfileType;
+import lombok.Builder;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Builder
+public record ProfileResponse(
+        long id,
+        MemberResponse member,
+        ProfileType type,
+        String name,
+        long balance,
+        LocalDate startDate,
+        LocalDateTime createdAt,
+        LocalDateTime updatedAt
+) {
+    public static ProfileResponse from(Profile profile) {
+        return ProfileResponse.builder()
+                .id(profile.getId())
+                .member(MemberResponse.from(profile.getMember()))
+                .type(profile.getType())
+                .name(profile.getName())
+                .balance(profile.getBalance())
+                .startDate(profile.getStartDate())
+                .createdAt(profile.getCreatedAt())
+                .updatedAt(profile.getUpdatedAt())
+                .build();
+    }
+}

--- a/src/main/java/farmsystem/backend/domain/profile/dto/response/ProfileResponse.java
+++ b/src/main/java/farmsystem/backend/domain/profile/dto/response/ProfileResponse.java
@@ -1,6 +1,6 @@
 package farmsystem.backend.domain.profile.dto.response;
 
-import farmsystem.backend.domain.member.dto.resposne.MemberResponse;
+import farmsystem.backend.domain.member.dto.response.MemberResponse;
 import farmsystem.backend.domain.profile.entity.Profile;
 import farmsystem.backend.domain.profile.entity.ProfileType;
 import lombok.Builder;

--- a/src/main/java/farmsystem/backend/domain/profile/entity/Profile.java
+++ b/src/main/java/farmsystem/backend/domain/profile/entity/Profile.java
@@ -1,7 +1,7 @@
 package farmsystem.backend.domain.profile.entity;
 
+import java.time.LocalDate;
 import java.util.ArrayList;
-import java.util.Date;
 import java.util.List;
 
 import farmsystem.backend.domain.common.entity.BaseTimeEntity;
@@ -9,6 +9,7 @@ import farmsystem.backend.domain.member.entity.Member;
 import farmsystem.backend.domain.trade.entity.Trade;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -35,7 +36,16 @@ public class Profile extends BaseTimeEntity {
     @Column(nullable = false)
     private long balance;
 
-    private Date startDate;
+    private LocalDate startDate;
+
+    @Builder
+    public Profile(Member member, String name, ProfileType type, long balance, LocalDate startDate) {
+        this.member = member;
+        this.name = name;
+        this.type = type;
+        this.balance = balance;
+        this.startDate = startDate;
+    }
 
     @OneToMany(mappedBy = "profile")
     private List<Trade> trades = new ArrayList<>();

--- a/src/main/java/farmsystem/backend/domain/profile/entity/Profile.java
+++ b/src/main/java/farmsystem/backend/domain/profile/entity/Profile.java
@@ -25,6 +25,9 @@ public class Profile extends BaseTimeEntity {
     @JoinColumn(name = "member_id")
     private Member member;
 
+    @Column(length = 10, nullable = false)
+    private String name;
+
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     private ProfileType type;

--- a/src/main/java/farmsystem/backend/domain/profile/repository/ProfileRepository.java
+++ b/src/main/java/farmsystem/backend/domain/profile/repository/ProfileRepository.java
@@ -1,0 +1,14 @@
+package farmsystem.backend.domain.profile.repository;
+
+import farmsystem.backend.domain.member.entity.Member;
+import farmsystem.backend.domain.profile.entity.Profile;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface ProfileRepository extends JpaRepository<Profile, Long> {
+
+    List<Profile> findAllByMember(Member member);
+}

--- a/src/main/java/farmsystem/backend/domain/profile/service/ProfileService.java
+++ b/src/main/java/farmsystem/backend/domain/profile/service/ProfileService.java
@@ -1,0 +1,41 @@
+package farmsystem.backend.domain.profile.service;
+
+import farmsystem.backend.domain.member.entity.Member;
+import farmsystem.backend.domain.member.repository.MemberRepository;
+import farmsystem.backend.domain.profile.dto.response.ProfileResponse;
+import farmsystem.backend.domain.profile.dto.request.CreateProfileRequest;
+import farmsystem.backend.domain.profile.entity.Profile;
+import farmsystem.backend.domain.profile.repository.ProfileRepository;
+import farmsystem.backend.global.error.ErrorCode;
+import farmsystem.backend.global.error.exception.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ProfileService {
+
+    private final MemberRepository memberRepository;
+    private final ProfileRepository profileRepository;
+
+    @Transactional
+    public ProfileResponse createProfile(Long memberId, CreateProfileRequest request) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new EntityNotFoundException(ErrorCode.MEMBER_NOT_FOUND));
+        Profile savedProfile = profileRepository.save(request.toEntity(member));
+        return ProfileResponse.from(savedProfile);
+    }
+
+    public List<ProfileResponse> getProfileList(Long memberId) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new EntityNotFoundException(ErrorCode.MEMBER_NOT_FOUND));
+        List<Profile> profiles = profileRepository.findAllByMember(member);
+        return profiles.stream()
+                .map(ProfileResponse::from)
+                .toList();
+    }
+}

--- a/src/main/java/farmsystem/backend/global/config/SecurityConfig.java
+++ b/src/main/java/farmsystem/backend/global/config/SecurityConfig.java
@@ -1,0 +1,27 @@
+package farmsystem.backend.global.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        return http
+                .csrf(AbstractHttpConfigurer::disable)
+                .formLogin(AbstractHttpConfigurer::disable)
+                .httpBasic(AbstractHttpConfigurer::disable)
+                .sessionManagement(sessionManagementConfigurer ->
+                        sessionManagementConfigurer.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .build();
+    }
+}

--- a/src/main/java/farmsystem/backend/global/error/ErrorCode.java
+++ b/src/main/java/farmsystem/backend/global/error/ErrorCode.java
@@ -35,6 +35,9 @@ public enum ErrorCode {
     JSON_PARSING_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "A001", "JSON 파싱에 실패하였습니다."),
     NO_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "A002", "저장된 리프레시 토큰이 없습니다."),
     INVALID_CREDENTIALS(HttpStatus.UNAUTHORIZED, "A003", "아이디나 비밀번호가 잘못되었습니다."),
+
+    // Member
+    MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "M001", "해당 회원을 찾을 수 없습니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,0 @@
-spring.application.name=backend


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- #2 
- close : #2 
<!-- 이슈 완료되었을 때만 close 붙여주세요 --> 

## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 설명해 주세요 -->
- Profile에 name 필드 추가
- 프로필 생성, 목록 조회 API 구현
- Lombok, MySQL, Spring Security 의존성 추가
- Swagger 실행에 필요한 Security 설정
- startDate에서 사용 중인 Date를  LocalDate로 변경

## 📢 참고 사항
<!-- 특별히 봐주었으면 하는 부분과 참고해야 할 사항이 있다면 작성해 주세요 -->
<!-- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->
- AuthenticationPrincipal 등 일단 임의로 사용했습니다. 
- MemberResponse 등 Member 관련 필요한 코드 미리 작성했습니다.
- Member 및 JWT 구현 다 되면 맞추어 수정하겠습니다!!

- SecurityConfig는 Swagger 실행만을 위해 필요한 설정만 했습니다! 수정 필요!!
- applicaiton.properties 삭제하고 gitignore에 application.yml 추가했습니다. 따로 공유 드릴게요!