### PR TITLE
[feat] 랭킹 조회 구현

### DIFF
--- a/src/main/java/farmsystem/backend/domain/member/authorize/CustomUserDetails.java
+++ b/src/main/java/farmsystem/backend/domain/member/authorize/CustomUserDetails.java
@@ -27,4 +27,8 @@ public class CustomUserDetails implements UserDetails {
     public String getUsername() {
         return member.getUsername();
     }
+
+    public Long getId() {
+        return member.getId();
+    }
 }

--- a/src/main/java/farmsystem/backend/domain/profile/repository/ProfileRepository.java
+++ b/src/main/java/farmsystem/backend/domain/profile/repository/ProfileRepository.java
@@ -15,4 +15,6 @@ public interface ProfileRepository extends JpaRepository<Profile, Long> {
     List<Profile> findAllByMember(Member member);
 
     Optional<Profile> findByMemberIdAndType(Long memberId, ProfileType type);
+
+    List<Profile> findByType(ProfileType type);
 }

--- a/src/main/java/farmsystem/backend/domain/trade/controller/RankingApi.java
+++ b/src/main/java/farmsystem/backend/domain/trade/controller/RankingApi.java
@@ -1,0 +1,25 @@
+package farmsystem.backend.domain.trade.controller;
+
+import farmsystem.backend.domain.trade.dto.response.SellTradeResponse;
+import farmsystem.backend.global.common.SuccessResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import org.springframework.http.ResponseEntity;
+
+public interface RankingApi {
+
+    @Operation(
+            summary = "자산 랭킹",
+            description = "자산 랭킹을 조회합니다."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "자산 랭킹 조회 성공",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = SellTradeResponse.class))),
+
+    })
+    ResponseEntity<SuccessResponse<?>> getAssetRanking();
+}

--- a/src/main/java/farmsystem/backend/domain/trade/controller/RankingController.java
+++ b/src/main/java/farmsystem/backend/domain/trade/controller/RankingController.java
@@ -1,0 +1,23 @@
+package farmsystem.backend.domain.trade.controller;
+
+import farmsystem.backend.domain.trade.service.RankingService;
+import farmsystem.backend.global.common.SuccessResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/ranking")
+public class RankingController implements RankingApi {
+
+    private final RankingService rankingService;
+
+    @GetMapping
+    public ResponseEntity<SuccessResponse<?>> getAssetRanking() {
+        return SuccessResponse.ok(rankingService.getAssetRanking());
+    }
+}

--- a/src/main/java/farmsystem/backend/domain/trade/controller/TradeApi.java
+++ b/src/main/java/farmsystem/backend/domain/trade/controller/TradeApi.java
@@ -1,5 +1,6 @@
 package farmsystem.backend.domain.trade.controller;
 
+import farmsystem.backend.domain.member.authorize.CustomUserDetails;
 import farmsystem.backend.domain.trade.dto.request.LiveTradeRequest;
 import farmsystem.backend.domain.trade.dto.request.VirtualTradeRequest;
 import farmsystem.backend.domain.trade.dto.response.SellTradeResponse;
@@ -11,8 +12,8 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestParam;
 
 public interface TradeApi {
 
@@ -48,6 +49,6 @@ public interface TradeApi {
             @ApiResponse(responseCode = "404", description = "프로필/종목을 찾을 수 없음"),
             @ApiResponse(responseCode = "500", description = "잔액이 부족함")
     })
-    ResponseEntity<SuccessResponse<?>> createLiveTrade(@RequestParam Long memberId,
+    ResponseEntity<SuccessResponse<?>> createLiveTrade(@AuthenticationPrincipal CustomUserDetails userDetails,
                                                       @Valid @RequestBody LiveTradeRequest request);
 }

--- a/src/main/java/farmsystem/backend/domain/trade/controller/TradeController.java
+++ b/src/main/java/farmsystem/backend/domain/trade/controller/TradeController.java
@@ -1,5 +1,6 @@
 package farmsystem.backend.domain.trade.controller;
 
+import farmsystem.backend.domain.member.authorize.CustomUserDetails;
 import farmsystem.backend.domain.trade.dto.request.LiveTradeRequest;
 import farmsystem.backend.domain.trade.dto.request.VirtualTradeRequest;
 import farmsystem.backend.domain.trade.service.TradeService;
@@ -7,6 +8,7 @@ import farmsystem.backend.global.common.SuccessResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -22,8 +24,9 @@ public class TradeController implements TradeApi {
     }
 
     @PostMapping("/live")
-    public ResponseEntity<SuccessResponse<?>> createLiveTrade(@RequestParam Long memberId,
+    public ResponseEntity<SuccessResponse<?>> createLiveTrade(@AuthenticationPrincipal CustomUserDetails userDetails,
                                                              @Valid @RequestBody LiveTradeRequest request) {
+        Long memberId = userDetails.getId();
         return SuccessResponse.created(tradeService.createLiveTrade(memberId, request));
     }
 }

--- a/src/main/java/farmsystem/backend/domain/trade/dto/response/AssetRankingResponse.java
+++ b/src/main/java/farmsystem/backend/domain/trade/dto/response/AssetRankingResponse.java
@@ -1,0 +1,16 @@
+package farmsystem.backend.domain.trade.dto.response;
+
+import lombok.Builder;
+
+@Builder
+public record AssetRankingResponse(
+        String name,
+        double asset
+) {
+    public static AssetRankingResponse of(String name, double asset) {
+        return AssetRankingResponse.builder()
+                .name(name)
+                .asset(asset)
+                .build();
+    }
+}

--- a/src/main/java/farmsystem/backend/domain/trade/service/RankingService.java
+++ b/src/main/java/farmsystem/backend/domain/trade/service/RankingService.java
@@ -1,0 +1,32 @@
+package farmsystem.backend.domain.trade.service;
+
+import farmsystem.backend.domain.profile.entity.Profile;
+import farmsystem.backend.domain.profile.entity.ProfileType;
+import farmsystem.backend.domain.profile.repository.ProfileRepository;
+import farmsystem.backend.domain.trade.dto.response.AssetRankingResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class RankingService {
+
+    private final ProfileRepository profileRepository;
+
+    // 자산 랭킹 조회
+    public List<AssetRankingResponse> getAssetRanking() {
+        List<Profile> profiles = profileRepository.findByType(ProfileType.LIVE);
+
+        profiles.sort(Comparator.comparingLong(Profile::getBalance).reversed()); // 정렬
+
+        return profiles.stream()
+                .map(profile -> AssetRankingResponse.of(profile.getMember().getUsername(), profile.getBalance()))
+                .collect(Collectors.toList());
+    }
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- close : #9
<!-- 이슈 완료되었을 때만 close 붙여주세요 --> 

## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 설명해 주세요 -->
- 자산(프로필별 balance) 랭킹 조회

## 📢 참고 사항
<!-- 특별히 봐주었으면 하는 부분과 참고해야 할 사항이 있다면 작성해 주세요 -->
<!-- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->
- 시점 모드 랭킹하려니 랭킹 매기는 정확한 기준(?)(시점 시작 일자가 다 다른데 어떤 기준으로 랭킹을 매겨야할지..) 정한게 없어서 현재가 기준으로 거래하는 프로필(LIVE)에 대해서만 정렬하도록 간단하게 구현했습니다 
- 컨트롤러단에서 ```@AuthenticationPrincipal CustomUserDetails userDetails``` 요걸로 ```Long memberId = userDetails.getId();``` 이렇게 memberId 받아오도록 급한대로 처리해뒀습니당 